### PR TITLE
[Fixing issue https://github.com/micronaut-projects/micronaut-data/iss…

### DIFF
--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/FetchByJoinTypeSpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/FetchByJoinTypeSpec.groovy
@@ -1,0 +1,79 @@
+package io.micronaut.data.hibernate.reactive
+
+import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.repository.reactive.ReactorCrudRepository
+import io.micronaut.data.tck.entities.Author
+import io.micronaut.data.tck.entities.AuthorBooksDto
+import io.micronaut.data.tck.entities.BookDto
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import reactor.core.publisher.Mono
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+import javax.transaction.Transactional
+
+@MicronautTest(transactional = false, packages = ["io.micronaut.data.tck.entities", "io.micronaut.data.hibernate.entities"])
+@Stepwise
+@Transactional
+class FetchByJoinTypeSpec extends Specification implements PostgresHibernateReactiveProperties {
+
+    @Repository
+    static interface AuthorLeftFetchRepository extends ReactorCrudRepository<Author, Long> {
+
+        @Join(value = "books", type = Join.Type.LEFT_FETCH)
+        @Transactional
+        Mono<Author> findByName(String name)
+
+    }
+
+    @Inject
+    @Shared
+    BookRepository bookRepository
+
+    @Inject
+    @Shared
+    AuthorRepository authorRepository
+
+    @Inject
+    private AuthorLeftFetchRepository leftFetchRepository
+
+
+    def setupSpec() {
+        bookRepository.saveAuthorBooks(authorRepository, [
+                new AuthorBooksDto("Stephen King", Arrays.asList(
+                        new BookDto("The Stand", 1000),
+                        new BookDto("Pet Cemetery", 400)
+                )),
+                new AuthorBooksDto("James Patterson", Arrays.asList(
+                        new BookDto("Along Came a Spider", 300),
+                        new BookDto("Double Cross", 300)
+                )),
+                new AuthorBooksDto("Don Winslow", Arrays.asList(
+                        new BookDto("The Power of the Dog", 600),
+                        new BookDto("The Border", 700)
+                ))]).block()
+    }
+
+    void "dummy test"() {
+        given:
+        def a = 1
+
+        expect:
+        a == 1
+    }
+
+    void "left fetch fetches books"() {
+        given:
+        def booksMap = leftFetchRepository.findByName("Stephen King").flatMap {
+            author -> Mono.fromSupplier {() -> author.books}
+        }.block().collectEntries {book -> [book.title, book.pages]}
+
+        expect:
+        booksMap.size() == 2
+//        booksMap.get("The Stand") == 1000
+    }
+
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2JoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2JoinFetchSpec.groovy
@@ -1,0 +1,89 @@
+package io.micronaut.data.jdbc.h2
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+import io.micronaut.inject.visitor.VisitorContext
+import jakarta.inject.Inject
+
+class H2JoinFetchSpec extends AbstractJoinFetchSpec implements H2TestPropertyProvider {
+
+    boolean outerJoinSupported = false
+
+    boolean outerFetchJoinSupported = false
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(H2BookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(H2AuthorRepository)
+    }
+
+    @Override
+    AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(H2AuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(H2AuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(H2AuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(H2AuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        throw new UnsupportedOperationException("Full Outer Join is not supported by H2.")
+    }
+
+    @Override
+    AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        throw new UnsupportedOperationException("Full Outer Join is not supported by H2.")
+    }
+
+    @Override
+    AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.createBean(H2AuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(H2AuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinFetchRepository extends AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinInnerRepository extends AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinLeftFetchRepository extends AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinLeftRepository extends AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinRightFetchRepository extends AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinRightRepository extends AuthorJoinRightRepository {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mariadb/MariaJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mariadb/MariaJoinFetchSpec.groovy
@@ -1,0 +1,7 @@
+package io.micronaut.data.jdbc.mariadb
+
+
+import io.micronaut.data.jdbc.mysql.MySqlDialectJoinFetchSpec
+
+class MariaJoinFetchSpec extends MySqlDialectJoinFetchSpec implements MariaTestPropertyProvider {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MySqlDialectJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MySqlDialectJoinFetchSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.data.jdbc.mysql
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+abstract class MySqlDialectJoinFetchSpec extends AbstractJoinFetchSpec {
+
+    boolean outerJoinSupported = false
+
+    boolean outerFetchJoinSupported = false
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(MySqlBookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(MySqlAuthorRepository)
+    }
+
+    @Override
+    AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(MySqlAuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(MySqlAuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(MySqlAuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(MySqlAuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        throw new UnsupportedOperationException("Full Outer Join is not supported by MySql.")
+    }
+
+    @Override
+    AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        throw new UnsupportedOperationException("Full Outer Join is not supported by MySql.")
+    }
+
+    @Override
+    AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.getBean(MySqlAuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(MySqlAuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinFetchRepository extends AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinInnerRepository extends AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinLeftFetchRepository extends AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinLeftRepository extends AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinRightFetchRepository extends AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinRightRepository extends AuthorJoinRightRepository {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MysqlJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MysqlJoinFetchSpec.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.data.jdbc.mysql
+
+class MysqlJoinFetchSpec extends MySqlDialectJoinFetchSpec implements MySQLTestPropertyProvider {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXEJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXEJoinFetchSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.data.jdbc.oraclexe
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+class OracleXEJoinFetchSpec extends AbstractJoinFetchSpec implements OracleTestPropertyProvider {
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(OracleXEBookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(OracleXEAuthorRepository)
+    }
+
+    @Override
+    AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(OracleXEAuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(OracleXEAuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(OracleXEAuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(OracleXEAuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        return context.getBean(OracleXEAuthorJoinOuterRepository)
+    }
+
+    @Override
+    AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        return context.getBean(OracleXEAuthorJoinOuterFetchRepository)
+    }
+
+    @Override
+    AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.getBean(OracleXEAuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(OracleXEAuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinFetchRepository extends AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinInnerRepository extends AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinLeftFetchRepository extends AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinLeftRepository extends AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinOuterFetchRepository extends AuthorJoinOuterFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinOuterRepository extends AuthorJoinOuterRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinRightFetchRepository extends AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinRightRepository extends AuthorJoinRightRepository {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresJoinFetchSpec.groovy
@@ -1,0 +1,100 @@
+package io.micronaut.data.jdbc.postgres
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.AuthorJoinFetchRepository
+import io.micronaut.data.tck.repositories.AuthorJoinInnerRepository
+import io.micronaut.data.tck.repositories.AuthorJoinLeftFetchRepository
+import io.micronaut.data.tck.repositories.AuthorJoinLeftRepository
+import io.micronaut.data.tck.repositories.AuthorJoinOuterFetchRepository
+import io.micronaut.data.tck.repositories.AuthorJoinOuterRepository
+import io.micronaut.data.tck.repositories.AuthorJoinRightFetchRepository
+import io.micronaut.data.tck.repositories.AuthorJoinRightRepository
+import io.micronaut.data.tck.repositories.AuthorRepository
+import io.micronaut.data.tck.repositories.BookRepository
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+class PostgresJoinFetchSpec extends AbstractJoinFetchSpec implements PostgresTestPropertyProvider {
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(PostgresBookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(PostgresAuthorRepository)
+    }
+
+    @Override
+    AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(PostgresAuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(PostgresAuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(PostgresAuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(PostgresAuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        return context.getBean(PostgresAuthorJoinOuterRepository)
+    }
+
+    @Override
+    AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        return context.getBean(PostgresAuthorJoinOuterFetchRepository)
+    }
+
+    @Override
+    AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.getBean(PostgresAuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(PostgresAuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinFetchRepository extends AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinInnerRepository extends AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinLeftFetchRepository extends AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinLeftRepository extends AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinOuterFetchRepository extends AuthorJoinOuterFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinOuterRepository extends AuthorJoinOuterRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinRightFetchRepository extends AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinRightRepository extends AuthorJoinRightRepository {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerJoinFetchSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.data.jdbc.sqlserver
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+class SqlServerJoinFetchSpec extends AbstractJoinFetchSpec implements MSSQLTestPropertyProvider {
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(MSBookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(MSAuthorRepository)
+    }
+
+    @Override
+    AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(MSAuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(MSAuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(MSAuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(MSAuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        return context.getBean(MSAuthorJoinOuterRepository)
+    }
+
+    @Override
+    AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        return context.getBean(MSAuthorJoinOuterFetchRepository)
+    }
+
+    @Override
+    AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.getBean(MSAuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(MSAuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinFetchRepository extends AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinInnerRepository extends AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinLeftFetchRepository extends AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinLeftRepository extends AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinOuterFetchRepository extends AuthorJoinOuterFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinOuterRepository extends AuthorJoinOuterRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinRightFetchRepository extends AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinRightRepository extends AuthorJoinRightRepository {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/Join.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/Join.java
@@ -18,6 +18,7 @@ package io.micronaut.data.annotation;
 import io.micronaut.data.annotation.repeatable.JoinSpecifications;
 
 import java.lang.annotation.*;
+import java.util.EnumSet;
 
 /**
  * A @Join defines how a join for a particular association path should be generated.
@@ -56,7 +57,13 @@ public @interface Join {
         RIGHT_FETCH,
         FETCH,
         INNER,
-        OUTER;
+        OUTER,
+        OUTER_FETCH;
+
+        /**
+         * An enumset of all enum values.
+         */
+        public static final EnumSet<Type> ALL_TYPES = EnumSet.allOf(Type.class);
 
         /**
          * @return an indicator telling whether join type is fetching

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/Dialect.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/Dialect.java
@@ -16,7 +16,12 @@
 package io.micronaut.data.model.query.builder.sql;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.data.annotation.Join;
 import io.micronaut.data.model.DataType;
+
+import java.util.EnumSet;
+
+import static io.micronaut.data.annotation.Join.Type.*;
 
 /**
  * The SQL dialect to use.
@@ -28,42 +33,63 @@ public enum Dialect {
     /**
      * H2 database.
      */
-    H2(true, false, true),
+    H2(true, false, true,
+        EnumSet.of(
+            DEFAULT,
+            LEFT,
+            LEFT_FETCH,
+            RIGHT,
+            RIGHT_FETCH,
+            FETCH,
+            INNER
+        )),
     /**
      * MySQL 5.5 or above.
      */
-    MYSQL(true, true, false),
+    MYSQL(true, true, false, EnumSet.of(
+        DEFAULT,
+        LEFT,
+        LEFT_FETCH,
+        RIGHT,
+        RIGHT_FETCH,
+        FETCH,
+        INNER
+    )),
     /**
      * Postgres 9.5 or later.
      */
-    POSTGRES(true, false, true),
+    POSTGRES(true, false, true, ALL_TYPES),
     /**
      * SQL server 2012 or above.
      */
-    SQL_SERVER(false, false, false),
+    SQL_SERVER(false, false, false, ALL_TYPES),
     /**
      * Oracle 12c or above.
      */
-    ORACLE(true, true, false),
+    ORACLE(true, true, false, ALL_TYPES),
     /**
      * Ansi compliant SQL.
      */
-    ANSI(true, false, true);
+    ANSI(true, false, true, ALL_TYPES);
 
     private final boolean supportsBatch;
     private final boolean stringUUID;
     private final boolean supportsArrays;
+
+    private final EnumSet<Join.Type> joinTypesSupported;
 
     /**
      * Allows customization of batch support.
      * @param supportsBatch If batch is supported
      * @param stringUUID Does the dialect require a string UUID
      * @param supportsArrays Does the dialect supports arrays
+     * @param joinTypesSupported EnumSet of supported join types.
      */
-    Dialect(boolean supportsBatch, boolean stringUUID, boolean supportsArrays) {
+    Dialect(boolean supportsBatch, boolean stringUUID, boolean supportsArrays, EnumSet<Join.Type> joinTypesSupported) {
         this.supportsBatch = supportsBatch;
         this.stringUUID = stringUUID;
         this.supportsArrays = supportsArrays;
+        this.joinTypesSupported = joinTypesSupported;
     }
 
     /**
@@ -106,4 +132,15 @@ public enum Dialect {
     public final boolean requiresStringUUID(@NonNull DataType type) {
         return type == DataType.UUID && this.stringUUID;
     }
+
+    /**
+     * Determines whether the join type is supported this dialect.
+     *
+     * @param joinType the join type
+     * @return True if the type is supported by this dialect.
+     */
+    public final boolean supportsJoinType(@NonNull Join.Type joinType) {
+        return this.joinTypesSupported.contains(joinType);
+    }
+
 }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -908,6 +908,10 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
 
     @Override
     public String resolveJoinType(Join.Type jt) {
+        if (!this.dialect.supportsJoinType(jt)) {
+            throw new IllegalArgumentException("Unsupported join type [" + jt + "] by dialect [" + this.dialect + "]");
+        }
+
         String joinType;
         switch (jt) {
             case LEFT:
@@ -919,6 +923,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
                 joinType = " RIGHT JOIN ";
                 break;
             case OUTER:
+            case OUTER_FETCH:
                 joinType = " FULL OUTER JOIN ";
                 break;
             default:

--- a/data-model/src/test/groovy/io/micronaut/data/model/annotation/JoinTypeSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/annotation/JoinTypeSpec.groovy
@@ -25,6 +25,7 @@ class JoinTypeSpec extends Specification {
         Join.Type.FETCH.isFetch()
         Join.Type.LEFT_FETCH.isFetch()
         Join.Type.RIGHT_FETCH.isFetch()
+        Join.Type.OUTER_FETCH.isFetch()
         !Join.Type.LEFT.isFetch()
         !Join.Type.RIGHT.isFetch()
         !Join.Type.DEFAULT.isFetch()

--- a/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
@@ -33,22 +33,7 @@ import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.model.query.builder.sql.SqlQueryBuilder
 import io.micronaut.data.model.query.factory.Projections
 import io.micronaut.data.model.runtime.RuntimePersistentEntity
-import io.micronaut.data.tck.entities.Book
-import io.micronaut.data.tck.entities.Car
-import io.micronaut.data.tck.entities.Challenge
-import io.micronaut.data.tck.entities.City
-import io.micronaut.data.tck.entities.CountryRegion
-import io.micronaut.data.tck.entities.Meal
-import io.micronaut.data.tck.entities.Product
-import io.micronaut.data.tck.entities.Restaurant
-import io.micronaut.data.tck.entities.Sale
-import io.micronaut.data.tck.entities.Shipment
-import io.micronaut.data.tck.entities.ShipmentWithIndex
-import io.micronaut.data.tck.entities.ShipmentWithIndexOnClass
-import io.micronaut.data.tck.entities.ShipmentWithIndexOnClassAndFields
-import io.micronaut.data.tck.entities.ShipmentWithIndexOnFields
-import io.micronaut.data.tck.entities.ShipmentWithIndexOnFieldsCompositeIndexes
-import io.micronaut.data.tck.entities.UuidEntity
+import io.micronaut.data.tck.entities.*
 import io.micronaut.data.tck.jdbc.entities.Project
 import io.micronaut.data.tck.jdbc.entities.UserRole
 import spock.lang.Requires
@@ -168,6 +153,94 @@ interface MyRepository {
 
         expect:
         encoded.query == 'SELECT book_.`id`,book_.`author_id`,book_.`genre_id`,book_.`title`,book_.`total_pages`,book_.`publisher_id`,book_.`last_updated`,book_genre_.`genre_name` AS genre_genre_name,book_author_.`name` AS author_name,book_author_.`nick_name` AS author_nick_name FROM `book` book_ LEFT JOIN `genre` book_genre_ ON book_.`genre_id`=book_genre_.`id` INNER JOIN `author` book_author_ ON book_.`author_id`=book_author_.`id` WHERE (book_.`id` = ?)'
+
+    }
+
+    void "test encode to-one join - single level, two join entities, outer joins"() {
+        given:
+        PersistentEntity entity = PersistentEntity.of(Book)
+        QueryModel q = QueryModel.from(entity)
+        q.idEq(new QueryParameter("test"))
+        q.join(entity.getPropertyByName("author") as Association, Join.Type.OUTER)
+        q.join(entity.getPropertyByName("genre") as Association, Join.Type.OUTER_FETCH)
+        QueryBuilder encoder = new SqlQueryBuilder(Dialect.POSTGRES)
+        def encoded = encoder.buildQuery(q)
+
+        expect:
+        encoded.query == 'SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated",book_genre_."genre_name" AS genre_genre_name FROM "book" book_ FULL OUTER JOIN "genre" book_genre_ ON book_."genre_id"=book_genre_."id" FULL OUTER JOIN "author" book_author_ ON book_."author_id"=book_author_."id" WHERE (book_."id" = ?)'
+
+    }
+
+
+    void "test encode to-one join - unsupported outer join throws exception for H2 Dialect"() {
+        given:
+        PersistentEntity entity = PersistentEntity.of(Book)
+        QueryModel q = QueryModel.from(entity)
+        q.join(entity.getPropertyByName("author") as Association, Join.Type.OUTER)
+        QueryBuilder encoder = new SqlQueryBuilder(Dialect.H2)
+
+        when:
+        encoder.buildQuery(q)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+
+        expect:
+        e.message == "Unsupported join type [OUTER] by dialect [H2]"
+
+    }
+
+    void "test encode to-one join - unsupported outer fetch join throws exception for H2 Dialect"() {
+        given:
+        PersistentEntity entity = PersistentEntity.of(Book)
+        QueryModel q = QueryModel.from(entity)
+        q.join(entity.getPropertyByName("author") as Association, Join.Type.OUTER_FETCH)
+        QueryBuilder encoder = new SqlQueryBuilder(Dialect.H2)
+
+        when:
+        encoder.buildQuery(q)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+
+        expect:AuthorJoinFe
+        e.message == "Unsupported join type [OUTER_FETCH] by dialect [H2]"
+
+    }
+
+    void "test encode to-one join - unsupported outer join throws exception for MYSQL Dialect"() {
+        given:
+        PersistentEntity entity = PersistentEntity.of(Book)
+        QueryModel q = QueryModel.from(entity)
+        q.join(entity.getPropertyByName("author") as Association, Join.Type.OUTER)
+        QueryBuilder encoder = new SqlQueryBuilder(Dialect.MYSQL)
+
+        when:
+        encoder.buildQuery(q)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+
+        expect:
+        e.message == "Unsupported join type [OUTER] by dialect [MYSQL]"
+
+    }
+
+    void "test encode to-one join - unsupported outer fetch join throws exception for MYSQL Dialect"() {
+        given:
+        PersistentEntity entity = PersistentEntity.of(Book)
+        QueryModel q = QueryModel.from(entity)
+        q.join(entity.getPropertyByName("author") as Association, Join.Type.OUTER_FETCH)
+        QueryBuilder encoder = new SqlQueryBuilder(Dialect.MYSQL)
+
+        when:
+        encoder.buildQuery(q)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+
+        expect:
+        e.message == "Unsupported join type [OUTER_FETCH] by dialect [MYSQL]"
 
     }
 

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractJoinFetchSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractJoinFetchSpec.groovy
@@ -1,0 +1,159 @@
+package io.micronaut.data.tck.tests
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.entities.AuthorBooksDto
+import io.micronaut.data.tck.repositories.*
+import spock.lang.AutoCleanup
+import spock.lang.Requires
+import spock.lang.Shared
+import spock.lang.Specification
+
+abstract class AbstractJoinFetchSpec extends Specification {
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext context = ApplicationContext.run(properties)
+
+    @Shared
+    boolean leftJoinSupported = true
+
+    @Shared
+    boolean leftFetchJoinSupported = true
+
+    @Shared
+    boolean rightJoinSupported = true
+
+    @Shared
+    boolean rightFetchJoinSupported = true
+
+    @Shared
+    boolean outerJoinSupported = true
+
+    @Shared
+    boolean outerFetchJoinSupported = true
+
+    @Shared
+    boolean fetchJoinSupported = true
+
+    @Shared
+    boolean innerJoinSupported = true
+
+    abstract BookRepository getBookRepository()
+    abstract AuthorRepository getAuthorRepository()
+
+    abstract AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository()
+
+    abstract AuthorJoinLeftRepository getAuthorJoinLeftRepository()
+
+    abstract AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository()
+
+    abstract AuthorJoinRightRepository getAuthorJoinRightRepository()
+
+    abstract AuthorJoinOuterRepository getAuthorJoinOuterRepository()
+
+    abstract AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository()
+
+    abstract AuthorJoinFetchRepository getAuthorJoinFetchRepository()
+
+    abstract AuthorJoinInnerRepository getAuthorJoinInnerRepository()
+
+    void setup() {
+        saveSampleBooks()
+    }
+
+    void cleanup() {
+        bookRepository?.deleteAll()
+        authorRepository?.deleteAll()
+    }
+
+    void saveSampleBooks() {
+        bookRepository.saveAuthorBooks([
+                new AuthorBooksDto("Stephen King", Arrays.asList(
+                        new io.micronaut.data.tck.entities.BookDto("The Stand", 1000),
+                        new io.micronaut.data.tck.entities.BookDto("Pet Sematary", 400)
+                ))
+        ])
+    }
+
+    @Requires({shared.leftJoinSupported})
+    void "left join does not fetch projected entities"() {
+        given:
+        def authors = getAuthorJoinLeftRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.isEmpty()
+    }
+
+    @Requires({shared.leftFetchJoinSupported})
+    void "left fetch join fetches projected entities"() {
+        given:
+        def authors = getAuthorJoinLeftFetchRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.title.containsAll(["The Stand", "Pet Sematary"])
+    }
+
+    @Requires({shared.rightJoinSupported})
+    void "right join does not fetch projected entities"() {
+        given:
+        def authors = getAuthorJoinRightRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.isEmpty()
+    }
+
+    @Requires({shared.rightFetchJoinSupported})
+    void "right fetch join fetches projected entities"() {
+        given:
+        def authors = getAuthorJoinRightFetchRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.title.containsAll(["The Stand", "Pet Sematary"])
+    }
+
+    @Requires({shared.outerJoinSupported})
+    void "outer join does not fetch projected entities"() {
+        given:
+        def authors = getAuthorJoinOuterRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.isEmpty()
+    }
+
+    @Requires({shared.outerFetchJoinSupported})
+    void "outer fetch join fetches projected entities"() {
+        given:
+        def authors = getAuthorJoinOuterFetchRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.title.containsAll(["The Stand", "Pet Sematary"])
+    }
+
+    @Requires({shared.fetchJoinSupported})
+    void "fetch join fetches projected entities"() {
+        given:
+        def authors = getAuthorJoinFetchRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.title.containsAll(["The Stand", "Pet Sematary"])
+    }
+
+    @Requires({shared.innerJoinSupported})
+    void "inner join does not fetch projected entities"() {
+        given:
+        def authors = getAuthorJoinInnerRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.isEmpty()
+    }
+
+
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinFetchRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinFetchRepository.java
@@ -1,0 +1,13 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorJoinFetchRepository {
+    @Join(value = "books", type = Join.Type.FETCH)
+    List<Author> findAll();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinInnerRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinInnerRepository.java
@@ -1,0 +1,13 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorJoinInnerRepository {
+    @Join(value = "books", type = Join.Type.INNER)
+    List<Author> findAll();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinLeftFetchRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinLeftFetchRepository.java
@@ -1,0 +1,13 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorJoinLeftFetchRepository {
+    @Join(value = "books", type = Join.Type.LEFT_FETCH)
+    List<Author> findAll();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinLeftRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinLeftRepository.java
@@ -1,0 +1,14 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorJoinLeftRepository {
+    @Join(value = "books", type = Join.Type.LEFT)
+    List<Author> findAll();
+
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinOuterFetchRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinOuterFetchRepository.java
@@ -1,0 +1,13 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorJoinOuterFetchRepository {
+    @Join(value = "books", type = Join.Type.OUTER_FETCH)
+    List<Author> findAll();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinOuterRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinOuterRepository.java
@@ -1,0 +1,13 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorJoinOuterRepository {
+    @Join(value = "books", type = Join.Type.OUTER)
+    List<Author> findAll();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinRightFetchRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinRightFetchRepository.java
@@ -1,0 +1,13 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorJoinRightFetchRepository {
+    @Join(value = "books", type = Join.Type.RIGHT_FETCH)
+    List<Author> findAll();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinRightRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinRightRepository.java
@@ -1,0 +1,13 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorJoinRightRepository {
+    @Join(value = "books", type = Join.Type.RIGHT)
+    List<Author> findAll();
+}

--- a/src/main/docs/guide/hibernate/hibernateJoinQueries.adoc
+++ b/src/main/docs/guide/hibernate/hibernateJoinQueries.adoc
@@ -19,7 +19,7 @@ snippet::example.ProductRepository[project-base="doc-examples/hibernate-example"
 
 <1> The ann:data.annotation.Join[] is used to indicate a `JOIN FETCH` clause should be included.
 
-Note that the ann:data.annotation.Join[] annotation is repeatable and hence can be specified multiple times for different associations. In addition, the `type` member of the annotation can be used to specify the join type, for example `LEFT`, `INNER` or `RIGHT`.
+Note that the ann:data.annotation.Join[] annotation is repeatable and hence can be specified multiple times for different associations. In addition, the `type` member of the annotation can be used to specify the join type, for example `LEFT`, `INNER`, `RIGHT` or `OUTER`.
 
 === JPA 2.1 Entity Graphs
 


### PR DESCRIPTION
…ues/1178

Addded OUTER_FETCH join type
Dialect enum - joinTypesSupported field
SqlQueryBuilder - throws exception when initializing a repository with an unsupported join type (i.e. H2 and MySql with OUTER and OUTER_FETCH) Repository tests in data-jdbc, unit tests in data-model